### PR TITLE
Fixes #60 [Proper timeDiff calculation for season sleeping]

### DIFF
--- a/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
+++ b/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
@@ -29,8 +29,11 @@ public class SeasonSleepHandler
             if (world.areAllPlayersAsleep())
             {
                 SeasonSavedData seasonData = SeasonHandler.getSeasonSavedData(world);
-                long i = (world.getWorldInfo().getWorldTime() % 24000L)  + 24000L;
-                long timeDiff = i - i % 24000L;
+                /*
+                 * 23460L is the tick value for Dawn (When a player wakes from bed)
+                 * Caveat: timeDiff may be negative if a mod edits when a player is allowed to sleep.
+                 */
+                long timeDiff = 23460L - (world.getWorldInfo().getWorldTime());
                 seasonData.seasonCycleTicks += timeDiff;
                 seasonData.markDirty();
                 SeasonHandler.sendSeasonUpdate(world);

--- a/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
+++ b/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
@@ -34,6 +34,9 @@ public class SeasonSleepHandler
                  * Caveat: timeDiff may be negative if a mod edits when a player is allowed to sleep.
                  */
                 long timeDiff = 23460L - (world.getWorldInfo().getWorldTime());
+                if (timeDiff <= 0) {
+                	timeDiff += 24000L; //This covers our caveat
+                }
                 seasonData.seasonCycleTicks += timeDiff;
                 seasonData.markDirty();
                 SeasonHandler.sendSeasonUpdate(world);


### PR DESCRIPTION
As commented in #60, the current code for season sleeping always adds 24000L to the season ticks. This code fixes this, and adds only the amount of ticks that sleeping has skipped.

The one caveat, which I've provided a fix for, was if another mod changes when players are allowed to sleep.