### PR TITLE
Fixed issue #252 - Game Crash

### DIFF
--- a/src/main/java/toughasnails/block/BlockTANTemperatureCoil.java
+++ b/src/main/java/toughasnails/block/BlockTANTemperatureCoil.java
@@ -96,7 +96,7 @@ public class BlockTANTemperatureCoil extends BlockContainer implements ITANBlock
 		        double d0 = (double)((float)pos.getX() + 0.4F + rand.nextFloat() * 0.2F);
 		        double d1 = (double)((float)pos.getY() + 0.7F + rand.nextFloat() * 0.3F);
 		        double d2 = (double)((float)pos.getZ() + 0.4F + rand.nextFloat() * 0.2F);
-		        ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
+		        ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, world, d0, d1, d2, 0.0D, 0.0D, 0.0D, new int[0]);
 	    	}
     	}
     }

--- a/src/main/java/toughasnails/core/ClientProxy.java
+++ b/src/main/java/toughasnails/core/ClientProxy.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.client.registry.IRenderFactory;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
@@ -83,14 +84,14 @@ public class ClientProxy extends CommonProxy
     }
     
     @Override
-    public void spawnParticle(TANParticleTypes type, double x, double y, double z, Object... info)
+    public void spawnParticle(TANParticleTypes type, World parWorld, double x, double y, double z, Object... info)
     {
         Minecraft minecraft = Minecraft.getMinecraft();
         Particle entityFx = null;
         switch (type)
         {
         case SNOWFLAKE:
-            entityFx = new EntitySnowflakeFX(minecraft.world, x, y, z, MathHelper.nextDouble(minecraft.world.rand, -0.03, 0.03), -0.02D, MathHelper.nextDouble(minecraft.world.rand, -0.03, 0.03));
+            entityFx = new EntitySnowflakeFX(parWorld, x, y, z, MathHelper.nextDouble(parWorld.rand, -0.03, 0.03), -0.02D, MathHelper.nextDouble(parWorld.rand, -0.03, 0.03));
             break;
         default:
             break;

--- a/src/main/java/toughasnails/core/CommonProxy.java
+++ b/src/main/java/toughasnails/core/CommonProxy.java
@@ -2,6 +2,7 @@ package toughasnails.core;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
+import net.minecraft.world.World;
 import toughasnails.particle.TANParticleTypes;
 
 public class CommonProxy
@@ -10,5 +11,5 @@ public class CommonProxy
     public void registerItemVariantModel(Item item, String name, int metadata) {}
     public void registerNonRenderingProperties(Block block) {}
     public void registerFluidBlockRendering(Block block, String name) {}
-    public void spawnParticle(TANParticleTypes type, double x, double y, double z, Object... info) {}
+    public void spawnParticle(TANParticleTypes type, World parWorld, double x, double y, double z, Object... info) {}
 }

--- a/src/main/java/toughasnails/entities/EntityFreeze.java
+++ b/src/main/java/toughasnails/entities/EntityFreeze.java
@@ -102,7 +102,7 @@ public class EntityFreeze extends EntityMob implements IMob
 
             for (int i = 0; i < 2; ++i)
             {
-            	ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, this.posX + (this.rand.nextDouble() - 0.5D) * (double)this.width, this.posY + this.rand.nextDouble() * (double)this.height, this.posZ + (this.rand.nextDouble() - 0.5D) * (double)this.width, 0.0D, 0.0D, 0.0D, new int[0]);
+            	ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, this.world, this.posX + (this.rand.nextDouble() - 0.5D) * (double)this.width, this.posY + this.rand.nextDouble() * (double)this.height, this.posZ + (this.rand.nextDouble() - 0.5D) * (double)this.width, 0.0D, 0.0D, 0.0D, new int[0]);
             }
         }
 

--- a/src/main/java/toughasnails/entities/projectile/EntityIceball.java
+++ b/src/main/java/toughasnails/entities/projectile/EntityIceball.java
@@ -220,7 +220,7 @@ public class EntityIceball extends Entity implements IProjectile
             this.motionX *= (double)f2;
             this.motionY *= (double)f2;
             this.motionZ *= (double)f2;
-            ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, this.posX, this.posY + 0.5D, this.posZ, 0.0D, 0.0D, 0.0D, new int[0]);
+            ToughAsNails.proxy.spawnParticle(TANParticleTypes.SNOWFLAKE, this.world, this.posX, this.posY + 0.5D, this.posZ, 0.0D, 0.0D, 0.0D, new int[0]);
             this.setPosition(this.posX, this.posY, this.posZ);
         }
         else


### PR DESCRIPTION
Fixes Issue #252  - Passes world instance instead of using ```minecraft.world```

When the player left the world with an Iceball/particle in the air, when they tried to relog back into the world the Minecraft.world is null when it tries to spawn the particle. Passing the instance of world fixes the issue and stops the crash.