### PR TITLE
fixed NPE in ObjectProximityModifier for 1.9.4/1.10.2

### DIFF
--- a/src/main/java/toughasnails/temperature/modifier/ObjectProximityModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/ObjectProximityModifier.java
@@ -91,6 +91,7 @@ public class ObjectProximityModifier extends TemperatureModifier
         World world = player.worldObj;
         Material material = state.getMaterial();
         Biome biome = world.getBiomeGenForCoords(player.getPosition());
+        if (state.getBlock().getRegistryName() == null) return 0.0F;
 
         String blockName = state.getBlock().getRegistryName().toString();
 


### PR DESCRIPTION
Brings the 1.11/1.12 NPE fix into 1.9.4/1.10.2. This does not modify any other files like PR #283 did.