### PR TITLE
Fixing Thirst Health Decrease in Peaceful Difficulty & Hypo and Hyperthermia change (1.11)

### DIFF
--- a/src/main/java/toughasnails/potion/PotionHyperthermia.java
+++ b/src/main/java/toughasnails/potion/PotionHyperthermia.java
@@ -1,7 +1,9 @@
 package toughasnails.potion;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
+import net.minecraft.world.EnumDifficulty;
 
 public class PotionHyperthermia extends TANPotion
 {
@@ -15,7 +17,11 @@ public class PotionHyperthermia extends TANPotion
     @Override
     public void performEffect(EntityLivingBase entity, int amplifier)
     {
-        entity.attackEntityFrom(DamageSource.GENERIC, 0.5F);
+    	EnumDifficulty enumdifficulty = entity.getEntityWorld().getDifficulty();
+    	if (!(entity instanceof EntityPlayer) || (enumdifficulty == EnumDifficulty.EASY && entity.getHealth() > 10.0F) || (enumdifficulty == EnumDifficulty.NORMAL && entity.getHealth() > 1.0F) || enumdifficulty == EnumDifficulty.HARD)
+    	{
+    		entity.attackEntityFrom(DamageSource.GENERIC, 0.5F);
+    	}
     }
     
     @Override

--- a/src/main/java/toughasnails/potion/PotionHypothermia.java
+++ b/src/main/java/toughasnails/potion/PotionHypothermia.java
@@ -1,7 +1,9 @@
 package toughasnails.potion;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
+import net.minecraft.world.EnumDifficulty;
 
 public class PotionHypothermia extends TANPotion
 {
@@ -15,7 +17,11 @@ public class PotionHypothermia extends TANPotion
     @Override
     public void performEffect(EntityLivingBase entity, int amplifier)
     {
-        entity.attackEntityFrom(DamageSource.GENERIC, 0.5F);
+    	EnumDifficulty enumdifficulty = entity.getEntityWorld().getDifficulty();
+    	if (!(entity instanceof EntityPlayer) || (enumdifficulty == EnumDifficulty.EASY && entity.getHealth() > 10.0F) || (enumdifficulty == EnumDifficulty.NORMAL && entity.getHealth() > 1.0F) || enumdifficulty == EnumDifficulty.HARD)
+    	{
+    		entity.attackEntityFrom(DamageSource.GENERIC, 0.5F);
+    	}
     }
     
     @Override

--- a/src/main/java/toughasnails/thirst/ThirstHandler.java
+++ b/src/main/java/toughasnails/thirst/ThirstHandler.java
@@ -78,8 +78,8 @@ public class ThirstHandler extends StatHandlerBase implements IThirst
 	                //Inflict thirst damage every 4 seconds
 	                if (this.thirstTimer >= 80)
 	                {
-	                    if (player.getHealth() > 10.0F || enumdifficulty == EnumDifficulty.HARD || player.getHealth() > 1.0F && enumdifficulty == EnumDifficulty.NORMAL)
-	                    {
+	                	if ((enumdifficulty == EnumDifficulty.EASY && player.getHealth() > 10.0F) || (enumdifficulty == EnumDifficulty.NORMAL && player.getHealth() > 1.0F) || enumdifficulty == EnumDifficulty.HARD)
+	                	{
 	                        player.attackEntityFrom(DamageSource.STARVE, 1.0F);
 	                    }
 	


### PR DESCRIPTION
First of all, while looking at the code for thirst (to easily replicate it for Hypo&Hyperthermia, more on that later), i noticed that in Peaceful, thirst still decreases the player's health to 10.
There was nothing to fix that from happening, while it should not decrease the player's health on the peaceful difficulty (same as Hunger).
Second of all, i changed Hypo and Hyperthermia to also take the difficulty in mind if the afflicted entity is a player.
This means:
Peaceful: No health decrease.
Easy: Health decreases until 10.
Normal: Health decreases until 1.
Hard: Health decreases until player dies.