### PR TITLE
Fix issue #107 (1.12.x)

### DIFF
--- a/src/main/java/toughasnails/temperature/TemperatureHandler.java
+++ b/src/main/java/toughasnails/temperature/TemperatureHandler.java
@@ -203,6 +203,8 @@ public class TemperatureHandler extends StatHandlerBase implements ITemperature
         if (this.externalModifiers.containsKey(name))
         {
             ExternalModifier modifier = this.externalModifiers.get(name);
+            modifier.setAmount(amount);
+            modifier.setRate(rate);
             modifier.setEndTime(this.temperatureTimer + duration);
         }
         else

--- a/src/main/java/toughasnails/temperature/modifier/TemperatureModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/TemperatureModifier.java
@@ -66,9 +66,19 @@ public abstract class TemperatureModifier implements ITemperatureModifier
             return this.amount;
         }
         
+        public void setAmount(int amount)
+        {
+            this.amount = amount;
+        }
+        
         public int getRate()
         {
             return this.rate;
+        }
+        
+        public void setRate(int rate)
+        {
+            this.rate = rate;
         }
         
         public int getEndTime()


### PR DESCRIPTION
When applying temperature modifiers, if a modifier with the same name is already applied, only the duration is updated (thereby causing problems with the heating / cooling coils as they both use the key "Climatisation")