### PR TITLE
Fix season desync when sleeping

### DIFF
--- a/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
+++ b/src/main/java/toughasnails/handler/season/SeasonSleepHandler.java
@@ -25,15 +25,24 @@ public class SeasonSleepHandler
         if (event.phase == Phase.START && event.side == Side.SERVER && SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASONS))
         {
             WorldServer world = (WorldServer)event.world;
-
+            boolean startedSleeping = false;//Maybe move this to save some workload
+            
             //Called before all players are awoken for the next day
             if (world.areAllPlayersAsleep())
             {
+                startedSleeping = true;
                 SeasonSavedData seasonData = SeasonHandler.getSeasonSavedData(world);
-                long timeDiff = 24000L - ((world.getWorldInfo().getWorldTime() + 24000L) % 24000L);
-                seasonData.seasonCycleTicks += timeDiff;
+                seasonData.seasonCycleTicks += (-world.getWorldInfo().getWorldTime() + 24000L/*Replace with configured daytime value*/) % 24000L /*Also Replace with configured daytime value*/;
                 seasonData.markDirty();
                 SeasonHandler.sendSeasonUpdate(world);
+            }
+            else if (startedSleeping == true)
+            {
+                SeasonSavedData seasonData = SeasonHandler.getSeasonSavedData(world);
+                seasonData.seasonCycleTicks +=  world.getWorldInfo().getWorldTime() % 24000L/*Replace with configured daytime value*/;
+                seasonData.markDirty();
+                SeasonHandler.sendSeasonUpdate(world);
+                
             }
         }
     }


### PR DESCRIPTION
This solves some desync issues with other mods and mc itself, splitting the season updating over two ticks, one before being woken up, adding the remaining time till midnight to the season and one after that adding the time after midnight.

Issues:
1) Produces more workload with one more var + double saving (decided for it for extra stability) + double getting the season data
2) To few time added when shutting down right in the tick you wake up - desync
3) More code complexity
Issue conclusion
--&gt; plus one boolean, plus one seasonsave, plus one season get, plus code

This edit expects:
1) The server to keep up while creating a boolean every tick
2) world.getWorldInfo().getWorldTime() to return a value between midnight 1 and midnight (24000L, unless otherwise configured)
3) The server to keep up with +100% season updating workload
4) The old method to be false, if point 2) applies bc to few time would be added to the seasons. If 2) is correct, the calculations would only account for time before midnight, which would require you (if you wanted to avoid desync) to wake up right at midnight

The edit fixes:
1) It modifies the current file so that a day in mc (1,2,3,...) always corresponds to the exact season time (in ticks), fixing some annoying desync
Example:
When having a 1 day subseason length and 24000L day length, Sleeping at 22000L on day one would first add 2000L to seasontime(which should be 22000L) right before waking up. Then when waking up at 3287L it would add that time to seasontime resulting in 27287L ( / 24000L -&gt; 1; % 24000L -&gt; 3287) resulting in a value reflecting that one day and 3287L have passed which would be the correct value

Being a mathematical change this should in no way interfere with different version