### PR TITLE
Patched the vanilla sky renderer in order to adjust the day-night cycle depending on the current season

### DIFF
--- a/src/main/java/toughasnails/asm/TANLoadingPlugin.java
+++ b/src/main/java/toughasnails/asm/TANLoadingPlugin.java
@@ -16,7 +16,7 @@ public class TANLoadingPlugin implements IFMLLoadingPlugin
     @Override
     public String[] getASMTransformerClass()
     {
-        return new String[] { "toughasnails.asm.transformer.CropDecayTransformer", "toughasnails.asm.transformer.EntityRendererTransformer", "toughasnails.asm.transformer.WorldTransformer" };
+        return new String[] { "toughasnails.asm.transformer.CropDecayTransformer", "toughasnails.asm.transformer.EntityRendererTransformer", "toughasnails.asm.transformer.WorldTransformer", "toughasnails.asm.transformer.WorldProviderTransformer" };
     }
 
     @Override

--- a/src/main/java/toughasnails/asm/transformer/WorldProviderTransformer.java
+++ b/src/main/java/toughasnails/asm/transformer/WorldProviderTransformer.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2016, the Biomes O' Plenty Team
+ * 
+ * This work is licensed under a Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License.
+ * 
+ * To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-nd/4.0/.
+ ******************************************************************************/
+package toughasnails.asm.transformer;
+
+import java.util.List;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import com.google.common.collect.Lists;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import toughasnails.asm.ASMHelper;
+import toughasnails.asm.ObfHelper;
+
+public class WorldProviderTransformer implements IClassTransformer
+{
+    private static final String[] CALCULATE_CELESTIAL_ANGLE_NAMES = new String[] { "calculateCelestialAngle", "func_76563_a", "a" };
+    
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass)
+    {
+        if (transformedName.equals("net.minecraft.world.WorldProvider"))
+        {
+            return transformWorldProvider(basicClass, !transformedName.equals(name));
+        }
+        
+        return basicClass;
+    }
+    
+    private byte[] transformWorldProvider(byte[] bytes, boolean obfuscatedClass)
+    {
+        //Decode the class from bytes
+        ClassNode classNode = new ClassNode();
+        ClassReader classReader = new ClassReader(bytes);
+        classReader.accept(classNode, 0);
+
+        List<String> successfulTransformations = Lists.newArrayList();
+        
+        //Iterate over the methods in the class
+        for (MethodNode methodNode : classNode.methods)
+        {
+            if (ASMHelper.methodEquals(methodNode, CALCULATE_CELESTIAL_ANGLE_NAMES, ObfHelper.createMethodDescriptor(obfuscatedClass, "F", "J", "F")))
+            { 
+                InsnList insnList = new InsnList();
+                
+                // Get the new celestial angle
+                insnList.add(new VarInsnNode(Opcodes.LLOAD, 1));
+                insnList.add(new VarInsnNode(Opcodes.FLOAD, 3));
+                insnList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "toughasnails/season/SeasonASMHelper", "calculateCelestialAngle", ObfHelper.createMethodDescriptor(obfuscatedClass, "F", "J", "F"), false));
+                insnList.add(new InsnNode(Opcodes.FRETURN));
+
+                //Substitute existing instructions with our new ones
+                methodNode.instructions.clear();
+                methodNode.instructions.insert(insnList);
+                
+                successfulTransformations.add(methodNode.name + " " + methodNode.desc);
+            }
+        }
+        
+        if (successfulTransformations.size() != 1) throw new RuntimeException("An error occurred transforming WorldProvider. Applied transformations: " + successfulTransformations.toString());
+        
+        //Encode the altered class back into bytes
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        classNode.accept(writer);
+        bytes = writer.toByteArray();
+        
+        return bytes;
+    }
+}

--- a/src/main/java/toughasnails/season/SeasonASMHelper.java
+++ b/src/main/java/toughasnails/season/SeasonASMHelper.java
@@ -13,6 +13,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Biomes;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -154,19 +155,19 @@ public class SeasonASMHelper
     // Calculates the sun duration in a day according to the current time of year (season)
     public static long calculateSunDuration(float latitude)
     {
-    	long minSunDuration = 2000; // TODO: Should depend on the given latitude
+    	long minSunDuration = 2000; // TODO: Should depend on the given latitude (or not)
     	long maxSunDuration = SeasonTime.ZERO.getDayDuration() - minSunDuration;
     	long sunDuration = 0;
     	long currentTime = SeasonHandler.clientSeasonCycleTicks;
     	float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 2.5F;
     	
-    	// Sun duration is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
-    	sunDuration = (long) ((Math.cos((currentTime + phaseShift) * Math.PI / (float) (SeasonTime.ZERO.getCycleDuration() / 2.0F)) + 1.0F) / 2.0F * (float) (maxSunDuration - minSunDuration) + minSunDuration);
-    	System.out.println("time:" + currentTime + "  sun duration:" + sunDuration);
+    	// The sun duration is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
+    	sunDuration = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxSunDuration - minSunDuration) + minSunDuration);
+    	//System.out.println("time:" + currentTime + "  sun duration:" + sunDuration);
     	return sunDuration;
     }
     
-    // Calculates the angle of sun and moon in the sky relative to a specified time (usually worldTime)
+    // Calculates the angle of the sun and the moon in the sky relative to a specified time (usually worldTime)
     public static float calculateCelestialAngle(long worldTime, float partialTicks)
     {
     	/* Values to return:
@@ -177,7 +178,7 @@ public class SeasonASMHelper
     	 * etc.
     	 */
         
-        // Adapt celestial angle to chosen day/night duration centered on midday and midnight...
+        // Adapt celestial angle to chosen day-night duration centered on midday and midnight
     	// TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
     	// TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
     	
@@ -186,11 +187,11 @@ public class SeasonASMHelper
     	long zenithTime = 6000;
     	float angle = 0;
     	
-    	// Lock sun at its zenith
+    	// Lock the sun at its zenith
     	if (sunDuration == 24000)
     		return 0.0F;
     	
-    	// Lock moon at its zenith
+    	// Lock the moon at its zenith
     	if (sunDuration == 0)
     		return 0.5F;
     	

--- a/src/main/java/toughasnails/season/SeasonASMHelper.java
+++ b/src/main/java/toughasnails/season/SeasonASMHelper.java
@@ -152,19 +152,19 @@ public class SeasonASMHelper
         }
     }
     
-    // Calculates the sun duration in a day according to the current time of year (season)
-    public static long calculateSunDuration(float latitude)
+    // Calculates the daytime according to the current time of year (season)
+    public static long calculateDaytime(float latitude)
     {
-    	long minSunDuration = 2000; // TODO: Should depend on the given latitude (or not)
-    	long maxSunDuration = SeasonTime.ZERO.getDayDuration() - minSunDuration;
-    	long sunDuration = 0;
+    	long minDaytime = 2000; // TODO: Should depend on the given latitude (or not)
+    	long maxDaytime = SeasonTime.ZERO.getDayDuration() - minDaytime;
+    	long daytime = 0;
     	long currentTime = SeasonHandler.clientSeasonCycleTicks;
     	float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 2.5F;
     	
-    	// The sun duration is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
-    	sunDuration = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxSunDuration - minSunDuration) + minSunDuration);
-    	//System.out.println("time:" + currentTime + "  sun duration:" + sunDuration);
-    	return sunDuration;
+    	// The daytime is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
+    	daytime = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxDaytime - minDaytime) + minDaytime);
+    	//System.out.println("time:" + currentTime + "  daytime:" + daytime);
+    	return daytime;
     }
     
     // Calculates the angle of the sun and the moon in the sky relative to a specified time (usually worldTime)
@@ -183,33 +183,33 @@ public class SeasonASMHelper
     	// TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
     	
     	float latitude = 0;
-    	long sunDuration = calculateSunDuration(latitude);
+    	long daytime = calculateDaytime(latitude);
     	long zenithTime = 6000;
     	float angle = 0;
     	
     	// Lock the sun at its zenith
-    	if (sunDuration == 24000)
+    	if (daytime == 24000)
     		return 0.0F;
     	
     	// Lock the moon at its zenith
-    	if (sunDuration == 0)
+    	if (daytime == 0)
     		return 0.5F;
     	
     	// Normalisation: makes the day phase contiguous so that it's easier to process the different celestial phases
-    	long dayTime = (worldTime + 6000) % 24000;
+    	long time = (worldTime + 6000) % 24000;
     	zenithTime += 6000;
     	
     	// Phase 1: daytime
-        if (dayTime >= zenithTime - sunDuration / 2 && dayTime <= zenithTime + sunDuration / 2)
-        	angle =  (float)(dayTime) / (float)(sunDuration) / 2.0F + 1.0F - 6000F / (float) sunDuration;
+        if (time >= zenithTime - daytime / 2 && time <= zenithTime + daytime / 2)
+        	angle =  (float)(time) / (float)(daytime) / 2.0F + 1.0F - 6000F / (float) daytime;
         
         // Phase 2: from sunset to midnight
-        else if (dayTime > zenithTime + sunDuration / 2)
-        	angle = 0.25F / (12000F - sunDuration / 2) * (float)(dayTime) + 1.5F - 6000F / (12000F - sunDuration / 2);
+        else if (time > zenithTime + daytime / 2)
+        	angle = 0.25F / (12000F - daytime / 2) * (float)(time) + 1.5F - 6000F / (12000F - daytime / 2);
         
         // Phase 3: from midnight to sunrise (should be almost the same as phase 2)
-        else if (dayTime < zenithTime - sunDuration / 2)
-        	angle = 0.25F / (12000F - sunDuration / 2) * (float)(dayTime + 24000) + 1.5F - 6000F / (12000F - sunDuration / 2);
+        else if (time < zenithTime - daytime / 2)
+        	angle = 0.25F / (12000F - daytime / 2) * (float)(time + 24000) + 1.5F - 6000F / (12000F - daytime / 2);
         
         if (angle > 1.0F)
     		--angle;


### PR DESCRIPTION
This change adds the ability to adjust the day-night cycle based on the current season time.
For instance, the sun duration reaches its maximum on the summer solstice (middle of the mid summer subseason) and is minimised on the winter solstice (middle of the mid winter subseason). To be more realistic, values between those two moments follow a sinusoidal function.
For now the min value of the sun duration is hardcoded (minSunDuration=2000). I propose to add it to the season config file. Another alternative is to calculate the sun duration based on latitude, but I think this option might be too low-level for end users.

Technically, this change makes celestial objects (sun, moon and stars) travel in the sky at a different speed according to the sun duration (if the sun duration is short, the sun moves fast while the moon, when it is its turn to show up, moves slowly).

#### Expected results
+ In the middle of mid summer (clientSeasonCycleTicks=540000), the sun duration reaches its maximum, which is 22000 ticks (24000 - 2000): the sun is slow
+ In the middle of mid winter (clientSeasonCycleTicks=1260000), the sun duration reaches its minimum, which is 2000 ticks: the sun is fast
+ In other cases, the sun duration is intermediate

#### TODO
+ Choose whether the day-night cycle should depend on latitude or not
+ Smoother shift between day and night
