### PR TITLE
Season-based day-night cycle #2

### DIFF
--- a/src/main/java/toughasnails/api/config/SeasonsOption.java
+++ b/src/main/java/toughasnails/api/config/SeasonsOption.java
@@ -13,8 +13,8 @@ public enum SeasonsOption implements ISyncedOption
     DAY_DURATION("Day Duration"),
     SUB_SEASON_DURATION("Sub Season Duration"),
     ENABLE_SEASON_DAYTIME("Enable Season-Based daytime"),
-	MIN_DAYTIME("Minimum Daytime");
-
+    MIN_DAYTIME("Minimum Daytime");
+    
     private final String optionName;
 
     SeasonsOption(String name)

--- a/src/main/java/toughasnails/api/config/SeasonsOption.java
+++ b/src/main/java/toughasnails/api/config/SeasonsOption.java
@@ -11,7 +11,9 @@ public enum SeasonsOption implements ISyncedOption
 {
     ENABLE_SEASONS("Enable Seasons"),
     DAY_DURATION("Day Duration"),
-    SUB_SEASON_DURATION("Sub Season Duration");
+    SUB_SEASON_DURATION("Sub Season Duration"),
+    ENABLE_SEASON_DAYTIME("Enable Season-Based daytime"),
+	MIN_DAYTIME("Minimum Daytime");
 
     private final String optionName;
 

--- a/src/main/java/toughasnails/api/config/SeasonsOption.java
+++ b/src/main/java/toughasnails/api/config/SeasonsOption.java
@@ -12,7 +12,7 @@ public enum SeasonsOption implements ISyncedOption
     ENABLE_SEASONS("Enable Seasons"),
     DAY_DURATION("Day Duration"),
     SUB_SEASON_DURATION("Sub Season Duration"),
-    ENABLE_SEASON_DAYTIME("Enable Season-Based daytime"),
+    ENABLE_SEASONAL_DAYTIME("Enable Seasonal Daytime"),
     MIN_DAYTIME("Minimum Daytime");
     
     private final String optionName;

--- a/src/main/java/toughasnails/config/SeasonsConfig.java
+++ b/src/main/java/toughasnails/config/SeasonsConfig.java
@@ -36,7 +36,7 @@ public class SeasonsConfig extends ConfigHandler
             addSyncedValue(SeasonsOption.ENABLE_SEASONS, true, "Toggle", "Seasons progress as days increase");
             addSyncedValue(SeasonsOption.DAY_DURATION, 24000, TIME_SETTINGS,"The duration of a Minecraft day in ticks", 20, Integer.MAX_VALUE);
             addSyncedValue(SeasonsOption.SUB_SEASON_DURATION, 5, TIME_SETTINGS,"The duration of a sub season in days", 1, Integer.MAX_VALUE);
-            addSyncedValue(SeasonsOption.ENABLE_SEASON_DAYTIME, true, "Toggle", "Daytime changes as days increase");
+            addSyncedValue(SeasonsOption.ENABLE_SEASONAL_DAYTIME, true, "Toggle", "Daytime changes as days increase");
             addSyncedValue(SeasonsOption.MIN_DAYTIME, 2000, TIME_SETTINGS,"The minimum daytime in ticks (reached on the winter solstice)", 0, Integer.MAX_VALUE);
             
             // Only applicable server-side

--- a/src/main/java/toughasnails/config/SeasonsConfig.java
+++ b/src/main/java/toughasnails/config/SeasonsConfig.java
@@ -36,6 +36,8 @@ public class SeasonsConfig extends ConfigHandler
             addSyncedValue(SeasonsOption.ENABLE_SEASONS, true, "Toggle", "Seasons progress as days increase");
             addSyncedValue(SeasonsOption.DAY_DURATION, 24000, TIME_SETTINGS,"The duration of a Minecraft day in ticks", 20, Integer.MAX_VALUE);
             addSyncedValue(SeasonsOption.SUB_SEASON_DURATION, 5, TIME_SETTINGS,"The duration of a sub season in days", 1, Integer.MAX_VALUE);
+            addSyncedValue(SeasonsOption.ENABLE_SEASON_DAYTIME, true, "Toggle", "Daytime changes as days increase");
+            addSyncedValue(SeasonsOption.MIN_DAYTIME, 2000, TIME_SETTINGS,"The minimum daytime in ticks (reached on the winter solstice)", 0, Integer.MAX_VALUE);
             
             // Only applicable server-side
             winterCropDeath = config.getBoolean("Enable Winter Crop Death", EVENT_SETTINGS, true, "Kill unheated crops during the winter");

--- a/src/main/java/toughasnails/season/SeasonASMHelper.java
+++ b/src/main/java/toughasnails/season/SeasonASMHelper.java
@@ -155,11 +155,11 @@ public class SeasonASMHelper
     // Calculates the daytime according to the current time of year (season)
     public static long calculateDaytime(float latitude)
     {
-    	long minDaytime = 2000; // TODO: Should depend on the given latitude (or not)
+    	long minDaytime = SyncedConfig.getIntValue(SeasonsOption.MIN_DAYTIME); // TODO: Should depend on the given latitude (or not)
     	long maxDaytime = SeasonTime.ZERO.getDayDuration() - minDaytime;
     	long daytime = 0;
     	long currentTime = SeasonHandler.clientSeasonCycleTicks;
-    	float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 2.5F;
+    	float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 3.0F;
     	
     	// The daytime is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
     	daytime = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxDaytime - minDaytime) + minDaytime);
@@ -177,42 +177,63 @@ public class SeasonASMHelper
     	 * sunrise: 0.75
     	 * etc.
     	 */
-        
-        // Adapt celestial angle to chosen day-night duration centered on midday and midnight
-    	// TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
-    	// TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
     	
-    	float latitude = 0;
-    	long daytime = calculateDaytime(latitude);
-    	long zenithTime = 6000;
     	float angle = 0;
     	
-    	// Lock the sun at its zenith
-    	if (daytime == 24000)
-    		return 0.0F;
-    	
-    	// Lock the moon at its zenith
-    	if (daytime == 0)
-    		return 0.5F;
-    	
-    	// Normalisation: makes the day phase contiguous so that it's easier to process the different celestial phases
-    	long time = (worldTime + 6000) % 24000;
-    	zenithTime += 6000;
-    	
-    	// Phase 1: daytime
-        if (time >= zenithTime - daytime / 2 && time <= zenithTime + daytime / 2)
-        	angle =  (float)(time) / (float)(daytime) / 2.0F + 1.0F - 6000F / (float) daytime;
-        
-        // Phase 2: from sunset to midnight
-        else if (time > zenithTime + daytime / 2)
-        	angle = 0.25F / (12000F - daytime / 2) * (float)(time) + 1.5F - 6000F / (12000F - daytime / 2);
-        
-        // Phase 3: from midnight to sunrise (should be almost the same as phase 2)
-        else if (time < zenithTime - daytime / 2)
-        	angle = 0.25F / (12000F - daytime / 2) * (float)(time + 24000) + 1.5F - 6000F / (12000F - daytime / 2);
-        
-        if (angle > 1.0F)
-    		--angle;
+    	// Checks whether season daytime is enabled
+    	if (SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASON_DAYTIME)) {
+    		// Adapt celestial angle to chosen day-night duration centered on midday and midnight
+        	// TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
+        	// TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
+        	
+        	float latitude = 0;
+        	long daytime = calculateDaytime(latitude);
+        	long zenithTime = 6000;
+        	
+        	// Lock the sun at its zenith
+        	if (daytime == 24000)
+        		return 0.0F;
+        	
+        	// Lock the moon at its zenith
+        	if (daytime == 0)
+        		return 0.5F;
+        	
+        	// Normalisation: makes the day phase contiguous so that it's easier to process the different celestial phases
+        	long time = (worldTime + 6000) % 24000;
+        	zenithTime += 6000;
+        	
+        	// Phase 1: daytime
+            if (time >= zenithTime - daytime / 2 && time <= zenithTime + daytime / 2)
+            	angle =  (float)(time) / (float)(daytime) / 2.0F + 1.0F - 6000F / (float) daytime;
+            
+            // Phase 2: from sunset to midnight
+            else if (time > zenithTime + daytime / 2)
+            	angle = 0.25F / (12000F - daytime / 2) * (float)(time) + 1.5F - 6000F / (12000F - daytime / 2);
+            
+            // Phase 3: from midnight to sunrise (should be almost the same as phase 2)
+            else if (time < zenithTime - daytime / 2)
+            	angle = 0.25F / (12000F - daytime / 2) * (float)(time + 24000) + 1.5F - 6000F / (12000F - daytime / 2);
+            
+            if (angle > 1.0F)
+        		--angle;
+    	}
+    	else {
+    		int i = (int)(worldTime % 24000L);
+            angle = ((float)i + partialTicks) / 24000.0F - 0.25F;
+
+            if (angle < 0.0F)
+            {
+                ++angle;
+            }
+
+            if (angle > 1.0F)
+            {
+                --angle;
+            }
+
+            float f1 = 1.0F - (float)((Math.cos((double)angle * Math.PI) + 1.0D) / 2.0D);
+            angle = angle + (f1 - angle) / 3.0F;
+    	}
         
     	//System.out.println("time=" + dayTime + " (real=" + worldTime + ") angle=" + angle);
         return angle;

--- a/src/main/java/toughasnails/season/SeasonASMHelper.java
+++ b/src/main/java/toughasnails/season/SeasonASMHelper.java
@@ -180,10 +180,9 @@ public class SeasonASMHelper
 
         float angle = 0;
 
-        // Checks whether season daytime is enabled
-        if (SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASON_DAYTIME)) {
+        // Checks whether seasonal daytime is enabled
+        if (SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASONAL_DAYTIME)) {
             // Adapt celestial angle to chosen day-night duration centered on midday and midnight
-            // TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
             // TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
 
             float latitude = 0;
@@ -218,8 +217,9 @@ public class SeasonASMHelper
                 --angle;
         }
         else {
+            // This is vanilla
             int i = (int)(worldTime % 24000L);
-            angle = ((float)i + partialTicks) / 24000.0F - 0.25F;
+            angle = ((float)i + partialTicks) / 24000.0F - 0.25F; // WTF are "partial ticks"?
 
             if (angle < 0.0F)
             {

--- a/src/main/java/toughasnails/season/SeasonASMHelper.java
+++ b/src/main/java/toughasnails/season/SeasonASMHelper.java
@@ -155,70 +155,70 @@ public class SeasonASMHelper
     // Calculates the daytime according to the current time of year (season)
     public static long calculateDaytime(float latitude)
     {
-    	long minDaytime = SyncedConfig.getIntValue(SeasonsOption.MIN_DAYTIME); // TODO: Should depend on the given latitude (or not)
-    	long maxDaytime = SeasonTime.ZERO.getDayDuration() - minDaytime;
-    	long daytime = 0;
-    	long currentTime = SeasonHandler.clientSeasonCycleTicks;
-    	float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 3.0F;
-    	
-    	// The daytime is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
-    	daytime = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxDaytime - minDaytime) + minDaytime);
-    	//System.out.println("time:" + currentTime + "  daytime:" + daytime);
-    	return daytime;
+        long minDaytime = SyncedConfig.getIntValue(SeasonsOption.MIN_DAYTIME); // TODO: Should depend on the given latitude (or not)
+        long maxDaytime = SeasonTime.ZERO.getDayDuration() - minDaytime;
+        long daytime = 0;
+        long currentTime = SeasonHandler.clientSeasonCycleTicks;
+        float phaseShift = (float) SeasonTime.ZERO.getSeasonDuration() * 3.0F;
+
+        // The daytime is maximised on the summer solstice and minimised on the winter solstice (for now it's a northern point of view)
+        daytime = (long) ((MathHelper.cos((float) ((currentTime + phaseShift) * Math.PI / ((float) SeasonTime.ZERO.getCycleDuration() / 2.0F))) + 1.0F) / 2.0F * (float) (maxDaytime - minDaytime) + minDaytime);
+        //System.out.println("time:" + currentTime + "  daytime:" + daytime);
+        return daytime;
     }
     
     // Calculates the angle of the sun and the moon in the sky relative to a specified time (usually worldTime)
     public static float calculateCelestialAngle(long worldTime, float partialTicks)
     {
-    	/* Values to return:
-    	 * midday: 0 (or 1 excluded)
-    	 * sunset: 0.25
-    	 * midnight: 0.5
-    	 * sunrise: 0.75
-    	 * etc.
-    	 */
-    	
-    	float angle = 0;
-    	
-    	// Checks whether season daytime is enabled
-    	if (SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASON_DAYTIME)) {
-    		// Adapt celestial angle to chosen day-night duration centered on midday and midnight
-        	// TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
-        	// TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
-        	
-        	float latitude = 0;
-        	long daytime = calculateDaytime(latitude);
-        	long zenithTime = 6000;
-        	
-        	// Lock the sun at its zenith
-        	if (daytime == 24000)
-        		return 0.0F;
-        	
-        	// Lock the moon at its zenith
-        	if (daytime == 0)
-        		return 0.5F;
-        	
-        	// Normalisation: makes the day phase contiguous so that it's easier to process the different celestial phases
-        	long time = (worldTime + 6000) % 24000;
-        	zenithTime += 6000;
-        	
-        	// Phase 1: daytime
+        /* Values to return:
+         * midday: 0 (or 1 excluded)
+         * sunset: 0.25
+         * midnight: 0.5
+         * sunrise: 0.75
+         * etc.
+         */
+
+        float angle = 0;
+
+        // Checks whether season daytime is enabled
+        if (SyncedConfig.getBooleanValue(SeasonsOption.ENABLE_SEASON_DAYTIME)) {
+            // Adapt celestial angle to chosen day-night duration centered on midday and midnight
+            // TODO: Vanilla code: WTF are "partial ticks"? What's the point of cos(f*pi)?
+            // TODO: Smoother acceleration between celestial phases (on sunset and on sunrise)
+
+            float latitude = 0;
+            long daytime = calculateDaytime(latitude);
+            long zenithTime = 6000;
+
+            // Lock the sun at its zenith
+            if (daytime == 24000)
+                return 0.0F;
+
+            // Lock the moon at its zenith
+            if (daytime == 0)
+                return 0.5F;
+
+            // Normalisation: makes the day phase contiguous so that it's easier to process the different celestial phases
+            long time = (worldTime + 6000) % 24000;
+            zenithTime += 6000;
+
+            // Phase 1: daytime
             if (time >= zenithTime - daytime / 2 && time <= zenithTime + daytime / 2)
-            	angle =  (float)(time) / (float)(daytime) / 2.0F + 1.0F - 6000F / (float) daytime;
-            
+                angle =  (float)(time) / (float)(daytime) / 2.0F + 1.0F - 6000F / (float) daytime;
+
             // Phase 2: from sunset to midnight
             else if (time > zenithTime + daytime / 2)
-            	angle = 0.25F / (12000F - daytime / 2) * (float)(time) + 1.5F - 6000F / (12000F - daytime / 2);
-            
+                angle = 0.25F / (12000F - daytime / 2) * (float)(time) + 1.5F - 6000F / (12000F - daytime / 2);
+
             // Phase 3: from midnight to sunrise (should be almost the same as phase 2)
             else if (time < zenithTime - daytime / 2)
-            	angle = 0.25F / (12000F - daytime / 2) * (float)(time + 24000) + 1.5F - 6000F / (12000F - daytime / 2);
-            
+                angle = 0.25F / (12000F - daytime / 2) * (float)(time + 24000) + 1.5F - 6000F / (12000F - daytime / 2);
+
             if (angle > 1.0F)
-        		--angle;
-    	}
-    	else {
-    		int i = (int)(worldTime % 24000L);
+                --angle;
+        }
+        else {
+            int i = (int)(worldTime % 24000L);
             angle = ((float)i + partialTicks) / 24000.0F - 0.25F;
 
             if (angle < 0.0F)
@@ -233,9 +233,9 @@ public class SeasonASMHelper
 
             float f1 = 1.0F - (float)((Math.cos((double)angle * Math.PI) + 1.0D) / 2.0D);
             angle = angle + (f1 - angle) / 3.0F;
-    	}
-        
-    	//System.out.println("time=" + dayTime + " (real=" + worldTime + ") angle=" + angle);
+        }
+
+        //System.out.println("time=" + dayTime + " (real=" + worldTime + ") angle=" + angle);
         return angle;
     }
 }

--- a/src/main/java/toughasnails/temperature/modifier/TimeModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/TimeModifier.java
@@ -1,6 +1,7 @@
 package toughasnails.temperature.modifier;
 
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import toughasnails.api.temperature.IModifierMonitor;
@@ -23,7 +24,7 @@ public class TimeModifier extends TemperatureModifier
         
         float extremityModifier = BiomeUtils.getBiomeTempExtremity(biome);
         //Reaches the highest point during the middle of the day and at midnight. Normalized to be between -1 and 1
-        float timeNorm = (-Math.abs(((worldTime + 6000) % 24000.0F) - 12000.0F) + 6000.0F) / 6000.0F;
+        float timeNorm = MathHelper.cos((float) (world.getCelestialAngle(worldTime) * 2.0F * Math.PI));
         
         int temperatureLevel = initialTemperature.getRawValue();
         int newTemperatureLevel = temperatureLevel;


### PR DESCRIPTION
Here is the sequel of #438.
Daytime can now be enabled or disabled at will, and its minimum value can be changed (cf. `seasons.cfg`).
On another note, the winter/summer solstice is now at the beginning of early winter/summer, as in real life.

