### PR TITLE
Synthetic classes crash CropDecayTransformer

### DIFF
--- a/src/main/java/toughasnails/asm/transformer/CropDecayTransformer.java
+++ b/src/main/java/toughasnails/asm/transformer/CropDecayTransformer.java
@@ -44,7 +44,7 @@ public class CropDecayTransformer implements IClassTransformer
             // Inject the hook used for crop decay
             return addRandomTickHook(basicClass, !transformedName.equals(name), transformedName, true);
         }
-        else
+        else if(basicClass != null)
         {
             // Check if some crop implements the interface, and if it does then inject the crop decay hook
             ClassReader classReader = new ClassReader(basicClass);


### PR DESCRIPTION
Fixes #393

As stated in http://develop.liteloader.com/liteloader/LiteLoader/issues/26#note_147 synthetic classes cause transformers to be called with `basicClass == null`, which crashes `CropDecayTransformer` when it tries to instantiate a `ClassReader` with that