### PR TITLE
Fix compatibility issues with thirst overlay

### DIFF
--- a/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
@@ -40,7 +40,7 @@ public class ThirstOverlayHandler
         }
     }
     
-    @SubscribeEvent(priority=EventPriority.HIGHEST)
+    @SubscribeEvent(priority=EventPriority.HIGHEST, receiveCanceled=true)
     public void onPreRenderOverlay(RenderGameOverlayEvent.Pre event)
     {
         if (event.getType() == ElementType.AIR && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))

--- a/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
@@ -6,18 +6,20 @@ import java.util.Random;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.GuiIngameForge;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
-import toughasnails.api.config.SyncedConfig;
 import toughasnails.api.TANCapabilities;
 import toughasnails.api.TANPotions;
 import toughasnails.api.config.GameplayOption;
+import toughasnails.api.config.SyncedConfig;
 import toughasnails.thirst.ThirstHandler;
 
 public class ThirstOverlayHandler
@@ -38,42 +40,29 @@ public class ThirstOverlayHandler
         }
     }
     
-    @SubscribeEvent
+    @SubscribeEvent(priority=EventPriority.HIGHEST)
     public void onPreRenderOverlay(RenderGameOverlayEvent.Pre event)
     {
         if (event.getType() == ElementType.AIR && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))
         {
-            GlStateManager.pushMatrix();
-            GlStateManager.translate(0.0F, -10.0F, 0.0F);
-        }
-    }
+            ScaledResolution resolution = event.getResolution();
+            int width = resolution.getScaledWidth();
+            int height = resolution.getScaledHeight();
+            EntityPlayerSP player = Minecraft.getMinecraft().player;
+            
+            ThirstHandler thirstStats = (ThirstHandler)player.getCapability(TANCapabilities.THIRST, null);
+            int thirstLevel = thirstStats.getThirst();
+            float thirstHydrationLevel = thirstStats.getHydration();
+            
+            //When the update counter isn't incrementing, ensure the same numbers are produced (freezes moving gui elements)
+            random.setSeed((long)(updateCounter * 312871));
     
-    @SubscribeEvent
-    public void onPostRenderOverlay(RenderGameOverlayEvent.Post event)
-    {
-        ScaledResolution resolution = event.getResolution();
-        int width = resolution.getScaledWidth();
-        int height = resolution.getScaledHeight();
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
-        
-        ThirstHandler thirstStats = (ThirstHandler)player.getCapability(TANCapabilities.THIRST, null);
-        int thirstLevel = thirstStats.getThirst();
-        float thirstHydrationLevel = thirstStats.getHydration();
-        
-        //When the update counter isn't incrementing, ensure the same numbers are produced (freezes moving gui elements)
-        random.setSeed((long)(updateCounter * 312871));
-        
-        if (event.getType() == ElementType.AIR && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))
-        {
-            GlStateManager.popMatrix();
-        }
-        else if (event.getType() == ElementType.EXPERIENCE && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))
-        {
-            minecraft.getTextureManager().bindTexture(OVERLAY);
-
             if (minecraft.playerController.gameIsSurvivalOrAdventure())
             {
+                minecraft.getTextureManager().bindTexture(OVERLAY);
                 drawThirst(width, height, thirstLevel, thirstHydrationLevel);
+                GuiIngameForge.right_height += 10;
+                minecraft.getTextureManager().bindTexture(Gui.ICONS);
             }
         }
     }

--- a/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
@@ -70,7 +70,7 @@ public class ThirstOverlayHandler
     private void drawThirst(int width, int height, int thirstLevel, float thirstHydrationLevel)
     {
         int left = width / 2 + 91;
-        int top = height - 49;
+        int top = height - GuiIngameForge.right_height;
         
         for (int i = 0; i < 10; i++)
         {


### PR DESCRIPTION
This change alleviates issues with other overlay handlers. This should prevent render glitches when the air overlay event is canceled (for example, my Metamorph fork). It should also fix overlaps with vanilla hud elements, and will most likely fix thirst becoming invisible when Ars Magica's mana overlay is present.