### PR TITLE
No temperature modifiers underground

### DIFF
--- a/src/main/java/toughasnails/config/TemperatureConfig.java
+++ b/src/main/java/toughasnails/config/TemperatureConfig.java
@@ -43,6 +43,8 @@ public class TemperatureConfig extends ConfigHandler
 
     public int wetModifier;
     public int snowModifier;
+    
+    public int undergroundDepth;
 
     public TemperatureConfig(File configFile)
     {
@@ -87,6 +89,8 @@ public class TemperatureConfig extends ConfigHandler
 
             wetModifier = config.getInt("Wet Modifier", MODIFIER_SETTINGS, -7, Integer.MIN_VALUE, 0, "The amount to decrease the temperature by when wet");
             snowModifier = config.getInt("Snow Modifier", MODIFIER_SETTINGS, -10, Integer.MIN_VALUE, 0, "The amount to decrease the temperature by when snowing");
+            
+            undergroundDepth = config.getInt("Underground Depth", MODIFIER_SETTINGS, 20, 0, Integer.MAX_VALUE, "The vertical distance between the surface and the underground level");
         }
         catch (Exception e)
         {

--- a/src/main/java/toughasnails/temperature/modifier/BiomeModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/BiomeModifier.java
@@ -7,6 +7,7 @@ import toughasnails.api.temperature.IModifierMonitor;
 import toughasnails.api.temperature.Temperature;
 import toughasnails.init.ModConfig;
 import toughasnails.util.BiomeUtils;
+import toughasnails.util.TerrainUtils;
 
 public class BiomeModifier extends TemperatureModifier
 {
@@ -29,7 +30,7 @@ public class BiomeModifier extends TemperatureModifier
         //Denormalize, multiply by the max temp offset, add to the current temp
         int newTemperatureLevel = initialTemperature.getRawValue();
         
-        if (pos.getY() > 50)
+        if (!(TerrainUtils.isUnderground(world, pos)))
         {
 	        if (!(biomeTemp < 0.65F && biomeTemp > 0.15F))
 	        {

--- a/src/main/java/toughasnails/temperature/modifier/SeasonModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/SeasonModifier.java
@@ -16,6 +16,7 @@ import toughasnails.api.season.SeasonHelper;
 import toughasnails.api.temperature.IModifierMonitor;
 import toughasnails.api.temperature.Temperature;
 import toughasnails.init.ModConfig;
+import toughasnails.util.TerrainUtils;
 
 public class SeasonModifier extends TemperatureModifier
 {
@@ -37,7 +38,7 @@ public class SeasonModifier extends TemperatureModifier
 
         if (world.provider.isSurfaceWorld())
         {
-        	if (pos.getY() > 55)
+        	if (!(TerrainUtils.isUnderground(world, pos)))
             {
 	            switch (season)
 		        {

--- a/src/main/java/toughasnails/temperature/modifier/TimeModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/TimeModifier.java
@@ -8,6 +8,7 @@ import toughasnails.api.temperature.IModifierMonitor;
 import toughasnails.api.temperature.Temperature;
 import toughasnails.init.ModConfig;
 import toughasnails.util.BiomeUtils;
+import toughasnails.util.TerrainUtils;
 
 public class TimeModifier extends TemperatureModifier
 {
@@ -29,7 +30,7 @@ public class TimeModifier extends TemperatureModifier
         int temperatureLevel = initialTemperature.getRawValue();
         int newTemperatureLevel = temperatureLevel;
 
-        if (world.provider.isSurfaceWorld() && ((timeNorm < 0 && ModConfig.temperature.enableNightTimeModifier)|| (timeNorm > 0 && ModConfig.temperature.enableDayTimeModifier)))
+        if (world.provider.isSurfaceWorld() && !(TerrainUtils.isUnderground(world, pos)) && ((timeNorm < 0 && ModConfig.temperature.enableNightTimeModifier)|| (timeNorm > 0 && ModConfig.temperature.enableDayTimeModifier)))
         {
         	newTemperatureLevel += ModConfig.temperature.timeModifier * timeNorm * (Math.max(1.0F, extremityModifier * ModConfig.temperature.timeExtremityMultiplier));
         }

--- a/src/main/java/toughasnails/util/TerrainUtils.java
+++ b/src/main/java/toughasnails/util/TerrainUtils.java
@@ -1,0 +1,13 @@
+package toughasnails.util;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import toughasnails.init.ModConfig;
+
+public class TerrainUtils
+{
+    public static boolean isUnderground(World world, BlockPos pos)
+    {
+        return pos.getY() <= world.getHeight((int)pos.getX(), (int)pos.getZ()) - ModConfig.temperature.undergroundDepth;
+    }
+}


### PR DESCRIPTION
This change makes external modifiers (weather, time, season) not apply under a configurable depth below the surface. Based on issue #374.

Expected result:
+ Underground temperature is near the equilibrium.

TODO:
+ Make it more gradual?