### PR TITLE
Fix inability of overwriting thirst ui

### DIFF
--- a/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/ThirstOverlayHandler.java
@@ -40,7 +40,7 @@ public class ThirstOverlayHandler
         }
     }
     
-    @SubscribeEvent(priority=EventPriority.HIGHEST, receiveCanceled=true)
+    @SubscribeEvent
     public void onPreRenderOverlay(RenderGameOverlayEvent.Pre event)
     {
         if (event.getType() == ElementType.AIR && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))


### PR DESCRIPTION
Get rid of priority and receiveCanceled from SubscribeEvent of onPreRenderOverlay to fix overwriting of thirst bar.