### PR TITLE
Allow drinking from water source blocks in the world and rain [...]

### DIFF
--- a/src/main/java/toughasnails/api/config/GameplayOption.java
+++ b/src/main/java/toughasnails/api/config/GameplayOption.java
@@ -11,7 +11,9 @@ public enum GameplayOption implements ISyncedOption
 {
 	ENABLE_TEMPERATURE("Enable Body Temperature"),
     ENABLE_THIRST("Enable Thirst"),
-    ENABLE_PEACEFUL("Enable Peaceful");
+    ENABLE_PEACEFUL("Enable Peaceful"),
+    ENABLE_THIRST_WORLD("Enable drinking from water blocks"),
+    ENABLE_THIRST_RAIN("Enable drinking from rain");
     
     private final String optionName;
     

--- a/src/main/java/toughasnails/api/thirst/WaterType.java
+++ b/src/main/java/toughasnails/api/thirst/WaterType.java
@@ -11,7 +11,7 @@ public enum WaterType
 {
     NORMAL("Water", 3, 0.1F, 0.75F), 
     PURIFIED("Purified Water", 6, 0.5F, 0.0F),
-    RAIN("Rain", 1, 0.1f, 0.0f);
+    RAIN("Rain", 1, 0.05F, 0.0F);
     
     private String description;
     private int thirst;

--- a/src/main/java/toughasnails/api/thirst/WaterType.java
+++ b/src/main/java/toughasnails/api/thirst/WaterType.java
@@ -10,7 +10,8 @@ package toughasnails.api.thirst;
 public enum WaterType 
 {
     NORMAL("Water", 3, 0.1F, 0.75F), 
-    PURIFIED("Purified Water", 6, 0.5F, 0.0F);
+    PURIFIED("Purified Water", 6, 0.5F, 0.0F),
+    RAIN("Rain", 1, 0.1f, 0.0f);
     
     private String description;
     private int thirst;

--- a/src/main/java/toughasnails/config/GameplayConfig.java
+++ b/src/main/java/toughasnails/config/GameplayConfig.java
@@ -31,6 +31,8 @@ public class GameplayConfig extends ConfigHandler
         	addSyncedValue(GameplayOption.ENABLE_TEMPERATURE, true, "Main Settings", "Players are affected by temperature");
             addSyncedValue(GameplayOption.ENABLE_THIRST, true, "Main Settings", "Players are affected by thirst.");
             addSyncedValue(GameplayOption.ENABLE_PEACEFUL, false, "Main Settings", "The effects of the mod will work on Peaceful difficulty.");
+            addSyncedValue(GameplayOption.ENABLE_THIRST_WORLD, true, "Main Settings", "Allows drinking directly from water-source blocks with sneak-rightclick and empty main hand");
+            addSyncedValue(GameplayOption.ENABLE_THIRST_RAIN, true, "Main Settings", "Allows drinking from rain by sneak-rightclick and empty main hand if looking up at raining sky.");
 
             iceCubeDrops = config.getBoolean("Ice Cube Drops", "Tweak Settings", true, "Ice Blocks drop Ice Cubes.");
             magmaShardDrops = config.getBoolean("Magma Shard Drops", "Tweak Settings", true, "Magma Blocks drop Magma Shards.");

--- a/src/main/java/toughasnails/config/GameplayConfig.java
+++ b/src/main/java/toughasnails/config/GameplayConfig.java
@@ -32,7 +32,7 @@ public class GameplayConfig extends ConfigHandler
             addSyncedValue(GameplayOption.ENABLE_THIRST, true, "Main Settings", "Players are affected by thirst.");
             addSyncedValue(GameplayOption.ENABLE_PEACEFUL, false, "Main Settings", "The effects of the mod will work on Peaceful difficulty.");
             addSyncedValue(GameplayOption.ENABLE_THIRST_WORLD, true, "Main Settings", "Allows drinking directly from water-source blocks with sneak-rightclick and empty main hand");
-            addSyncedValue(GameplayOption.ENABLE_THIRST_RAIN, true, "Main Settings", "Allows drinking from rain by sneak-rightclick and empty main hand if looking up at raining sky.");
+            addSyncedValue(GameplayOption.ENABLE_THIRST_RAIN, false, "Main Settings", "Allows drinking from rain by sneak-rightclick and empty main hand if looking up at raining sky.");
 
             iceCubeDrops = config.getBoolean("Ice Cube Drops", "Tweak Settings", true, "Ice Blocks drop Ice Cubes.");
             magmaShardDrops = config.getBoolean("Magma Shard Drops", "Tweak Settings", true, "Magma Blocks drop Magma Shards.");

--- a/src/main/java/toughasnails/handler/PacketHandler.java
+++ b/src/main/java/toughasnails/handler/PacketHandler.java
@@ -4,10 +4,7 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import toughasnails.core.ToughAsNails;
-import toughasnails.network.message.MessageSyncConfigs;
-import toughasnails.network.message.MessageTemperatureClient;
-import toughasnails.network.message.MessageToggleUI;
-import toughasnails.network.message.MessageUpdateStat;
+import toughasnails.network.message.*;
 
 public class PacketHandler
 {
@@ -19,5 +16,6 @@ public class PacketHandler
         instance.registerMessage(MessageTemperatureClient.class, MessageTemperatureClient.class, 1, Side.CLIENT);
         instance.registerMessage(MessageToggleUI.class, MessageToggleUI.class, 2, Side.CLIENT);
         instance.registerMessage(MessageSyncConfigs.class, MessageSyncConfigs.class, 4, Side.CLIENT);
+        instance.registerMessage(MessageDrinkWaterInWorld.class, MessageDrinkWaterInWorld.class, 5, Side.SERVER);
     }
 }

--- a/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
@@ -129,6 +129,8 @@ public class DrinkHandler
                 PacketHandler.instance.sendToServer(new MessageDrinkWaterInWorld());
                 // play drink sound
                 player.playSound(SoundEvents.ENTITY_GENERIC_DRINK, 0.5f, 1.0f);
+                // swing hand
+                player.swingArm(EnumHand.MAIN_HAND);
             } else {
                 // do thirst
                 applyDrinkFromWaterType(player, targetWater);

--- a/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
@@ -143,7 +143,7 @@ public class DrinkHandler
         WaterType hitBlock = null;
         // first do rain check (cheaper)
         if (SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST_RAIN) &&
-                player.world.isRaining() &&
+                player.world.isRainingAt(player.getPosition()) &&
                 (-75.0f > player.rotationPitch) && // 75 degrees is mostly upwards
                 (player.world.canSeeSky(player.getPosition())))
         {

--- a/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
@@ -7,13 +7,21 @@
  ******************************************************************************/
 package toughasnails.handler.thirst;
 
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
+import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.potion.PotionUtils;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.event.entity.living.LivingEntityUseItemEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
 import toughasnails.api.TANPotions;
 import toughasnails.api.config.GameplayOption;
 import toughasnails.api.config.SyncedConfig;
@@ -22,7 +30,10 @@ import toughasnails.api.stat.capability.IThirst;
 import toughasnails.api.thirst.ThirstHelper;
 import toughasnails.api.thirst.WaterType;
 import toughasnails.config.json.DrinkData;
+import toughasnails.fluids.blocks.BlockPurifiedWaterFluid;
+import toughasnails.handler.PacketHandler;
 import toughasnails.init.ModConfig;
+import toughasnails.network.message.MessageDrinkWaterInWorld;
 import toughasnails.thirst.ThirstHandler;
 
 public class DrinkHandler
@@ -75,7 +86,7 @@ public class DrinkHandler
                         {
                             if (drinkData.getPredicate().apply(stack))
                             {
-                                applyDrinkStats(player, drinkData);
+                                applyDrinkFromData(player, drinkData);
                                 break;
                             }
                         }
@@ -87,12 +98,88 @@ public class DrinkHandler
         }
     }
 
-    private void applyDrinkStats(EntityPlayer player, DrinkData data)
+    @SubscribeEvent
+    public void onRightClickBlock(final PlayerInteractEvent.RightClickBlock event)
     {
-        IThirst thirst = ThirstHelper.getThirstData(player);
-        thirst.addStats(data.getThirstRestored(), data.getHydrationRestored());
+        // only do tryDrinkWaterInWorld on client-side if the player is sneaking and has an empty main hand
+        if (canWorldDrink(event) && event.getEntityPlayer().isSneaking())
+            tryDrinkWaterInWorld(event.getEntityPlayer(), true);
+    }
 
-        if (player.world.rand.nextFloat() < data.getPoisonChance() && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))
+    // RightClickEmpty is only fired client-side, so we use a custom packet for either case
+    @SubscribeEvent
+    public void RightClickEmpty(final PlayerInteractEvent.RightClickEmpty event)
+    {
+        // only do tryDrinkWaterInWorld on client-side if the player is sneaking and has an empty main hand
+        if (canWorldDrink(event) && event.getEntityPlayer().isSneaking())
+            tryDrinkWaterInWorld(event.getEntityPlayer(), true);
+    }
+
+    private boolean canWorldDrink(final PlayerInteractEvent event) {
+        return (SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST_WORLD) || SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST_RAIN)) &&
+                (EnumHand.MAIN_HAND == event.getHand()) &&
+                (Side.CLIENT == event.getSide());
+    }
+
+    public static void tryDrinkWaterInWorld(final EntityPlayer player, final boolean isClient) {
+        final WaterType targetWater = getRightClickedWater(player);
+        if (null != targetWater) {
+            if (isClient) {
+                // send server packet
+                PacketHandler.instance.sendToServer(new MessageDrinkWaterInWorld());
+                // play drink sound
+                player.playSound(SoundEvents.ENTITY_GENERIC_DRINK, 0.5f, 1.0f);
+            } else {
+                // do thirst
+                applyDrinkFromWaterType(player, targetWater);
+            }
+        }
+    }
+
+    // used by both client (pre-packet) and server
+    private static WaterType getRightClickedWater(final EntityPlayer player) {
+        WaterType hitBlock = null;
+        // first do rain check (cheaper)
+        if (SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST_RAIN) &&
+                player.world.isRaining() &&
+                (-75.0f > player.rotationPitch) && // 75 degrees is mostly upwards
+                (player.world.canSeeSky(player.getPosition())))
+        {
+            hitBlock = WaterType.RAIN;
+        } else if (SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST_WORLD)) {
+            // do raytrace for liquid blocks within reach distance of player
+            final Vec3d vecPlayerOrigin = player.getPositionEyes(1.0f);
+            final Vec3d vecPlayerLook = player.getLook(1.0f);
+            final double playerReachDistance = player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
+            final Vec3d vecPlayerSee = vecPlayerOrigin.addVector(vecPlayerLook.x * playerReachDistance, vecPlayerLook.y * playerReachDistance, vecPlayerLook.z * playerReachDistance);
+            final RayTraceResult raytraceResult = player.getEntityWorld().rayTraceBlocks(vecPlayerOrigin, vecPlayerSee, true, false, false);
+            if ((null != raytraceResult) && (RayTraceResult.Type.BLOCK == raytraceResult.typeOfHit)) {
+                final IBlockState iblockstate = player.getEntityWorld().getBlockState(raytraceResult.getBlockPos());
+                final Material material = iblockstate.getMaterial();
+                if (material.equals(Material.WATER)) {
+                    hitBlock = (iblockstate.getBlock() instanceof BlockPurifiedWaterFluid) ? WaterType.PURIFIED : WaterType.NORMAL;
+                }
+            }
+        }
+        return hitBlock;
+    }
+
+    private static void applyDrinkFromData(final EntityPlayer player, final DrinkData data)
+    {
+        applyDrink(player, data.getThirstRestored(), data.getHydrationRestored(), data.getPoisonChance());
+    }
+
+    private static void applyDrinkFromWaterType(final EntityPlayer player, final WaterType waterType)
+    {
+        applyDrink(player, waterType.getThirst(), waterType.getHydration(), waterType.getPoisonChance());
+    }
+
+    private static void applyDrink(final EntityPlayer player, final int thirstRestored, final float hydrationRestored, final float poisonChance)
+    {
+        IThirst thirstStats = ThirstHelper.getThirstData(player);
+        thirstStats.addStats(thirstRestored, hydrationRestored);
+
+        if (!player.world.isRemote && (player.world.rand.nextFloat() < poisonChance) && SyncedConfig.getBooleanValue(GameplayOption.ENABLE_THIRST))
         {
             player.addPotionEffect(new PotionEffect(TANPotions.thirst, 600));
         }

--- a/src/main/java/toughasnails/network/message/MessageDrinkWaterInWorld.java
+++ b/src/main/java/toughasnails/network/message/MessageDrinkWaterInWorld.java
@@ -1,0 +1,35 @@
+package toughasnails.network.message;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.relauncher.Side;
+import toughasnails.handler.thirst.DrinkHandler;
+
+/**
+ * @author Daniel 'CosmicDan' Connolly
+ */
+public class MessageDrinkWaterInWorld implements IMessage, IMessageHandler<MessageDrinkWaterInWorld, IMessage> {
+	private boolean isRain;
+
+	public MessageDrinkWaterInWorld() {}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {}
+
+	@Override
+	public void toBytes(ByteBuf buf) {}
+
+	@Override
+	public IMessage onMessage(MessageDrinkWaterInWorld message, MessageContext ctx)
+	{
+		if (Side.SERVER == ctx.side)
+		{
+			final EntityPlayerMP player = ctx.getServerHandler().player;
+			DrinkHandler.tryDrinkWaterInWorld(player, false);
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Configurable, default enabled for both.

Basic logic flow:
1) Check if drinking is enabled/possible on two PlayerInteractEvents - RightClickEmpty (client-side only event) and RightClickBlock. Both are only hooked client-side.
2) Determine if the player is looking at a raining sky (checked first since it's cheaper), a water source block, or neither.
3) If looking at a valid drink block/raining sky via raytrace, send a packet to the server
4) Server packet receive performs #2 again on its own side
5) Apply drink based on detected water source.

Let me know if anything isn't to your standards. Cheers.