### PR TITLE
Process all packets on main thread

### DIFF
--- a/src/main/java/toughasnails/network/message/MessageDrinkWaterInWorld.java
+++ b/src/main/java/toughasnails/network/message/MessageDrinkWaterInWorld.java
@@ -2,6 +2,7 @@ package toughasnails.network.message;
 
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
@@ -28,7 +29,7 @@ public class MessageDrinkWaterInWorld implements IMessage, IMessageHandler<Messa
 		if (Side.SERVER == ctx.side)
 		{
 			final EntityPlayerMP player = ctx.getServerHandler().player;
-			DrinkHandler.tryDrinkWaterInWorld(player, false);
+			player.getServerWorld().addScheduledTask(() -> DrinkHandler.tryDrinkWaterInWorld(player, false));
 		}
 		return null;
 	}

--- a/src/main/java/toughasnails/network/message/MessageSyncConfigs.java
+++ b/src/main/java/toughasnails/network/message/MessageSyncConfigs.java
@@ -8,6 +8,7 @@
 package toughasnails.network.message;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
@@ -46,19 +47,20 @@ public class MessageSyncConfigs implements IMessage, IMessageHandler<MessageSync
     {
         if (ctx.side == Side.CLIENT)
         {
-            for (String key : message.nbtOptions.getKeySet())
+            Minecraft.getMinecraft().addScheduledTask(() ->
             {
-                SyncedConfigEntry entry = SyncedConfig.optionsToSync.get(key);
-                
-                if (entry == null)
-                {
-                    ToughAsNails.logger.error("Option " + key + " does not exist locally!");
-                    continue; // Don't try access non-exist option
+                for (String key : message.nbtOptions.getKeySet()) {
+                    SyncedConfigEntry entry = SyncedConfig.optionsToSync.get(key);
+
+                    if (entry == null) {
+                        ToughAsNails.logger.error("Option " + key + " does not exist locally!");
+                        continue; // Don't try access non-exist option
+                    }
+
+                    entry.value = message.nbtOptions.getString(key);
+                    ToughAsNails.logger.info("TAN configuration synchronized with the server");
                 }
-                
-                entry.value = message.nbtOptions.getString(key);
-                ToughAsNails.logger.info("TAN configuration synchronized with the server");
-            }
+            });
         }
         
         return null;

--- a/src/main/java/toughasnails/network/message/MessageSyncConfigs.java
+++ b/src/main/java/toughasnails/network/message/MessageSyncConfigs.java
@@ -50,7 +50,11 @@ public class MessageSyncConfigs implements IMessage, IMessageHandler<MessageSync
             {
                 SyncedConfigEntry entry = SyncedConfig.optionsToSync.get(key);
                 
-                if (entry == null) ToughAsNails.logger.error("Option " + key + " does not exist locally!");
+                if (entry == null)
+                {
+                    ToughAsNails.logger.error("Option " + key + " does not exist locally!");
+                    continue; // Don't try access non-exist option
+                }
                 
                 entry.value = message.nbtOptions.getString(key);
                 ToughAsNails.logger.info("TAN configuration synchronized with the server");

--- a/src/main/java/toughasnails/network/message/MessageTemperatureClient.java
+++ b/src/main/java/toughasnails/network/message/MessageTemperatureClient.java
@@ -88,13 +88,16 @@ public class MessageTemperatureClient implements IMessage, IMessageHandler<Messa
 
             if (player != null)
             {
-                TemperatureHandler temperatureStats = (TemperatureHandler)player.getCapability(TANCapabilities.TEMPERATURE, null);
-                TemperatureDebugger debugger = temperatureStats.debugger;
-                
-                debugger.temperatureTimer = message.temperatureTimer;
-                debugger.changeTicks = message.changeTicks;
-                debugger.targetTemperature = message.targetTemperature;
-                debugger.modifiers = message.modifiers;
+                Minecraft.getMinecraft().addScheduledTask(() ->
+                {
+                    TemperatureHandler temperatureStats = (TemperatureHandler) player.getCapability(TANCapabilities.TEMPERATURE, null);
+                    TemperatureDebugger debugger = temperatureStats.debugger;
+
+                    debugger.temperatureTimer = message.temperatureTimer;
+                    debugger.changeTicks = message.changeTicks;
+                    debugger.targetTemperature = message.targetTemperature;
+                    debugger.modifiers = message.modifiers;
+                });
             }
         }
         

--- a/src/main/java/toughasnails/network/message/MessageToggleUI.java
+++ b/src/main/java/toughasnails/network/message/MessageToggleUI.java
@@ -43,10 +43,13 @@ public class MessageToggleUI implements IMessage, IMessageHandler<MessageToggleU
 
             if (player != null)
             {
-                TemperatureHandler temperatureStats = (TemperatureHandler)player.getCapability(TANCapabilities.TEMPERATURE, null);
-                TemperatureDebugger debugger = temperatureStats.debugger;
-                
-                debugger.setGuiVisible(message.showDebugGUI);
+                Minecraft.getMinecraft().addScheduledTask(() ->
+                {
+                    TemperatureHandler temperatureStats = (TemperatureHandler) player.getCapability(TANCapabilities.TEMPERATURE, null);
+                    TemperatureDebugger debugger = temperatureStats.debugger;
+
+                    debugger.setGuiVisible(message.showDebugGUI);
+                });
             }
         }
         

--- a/src/main/java/toughasnails/network/message/MessageUpdateStat.java
+++ b/src/main/java/toughasnails/network/message/MessageUpdateStat.java
@@ -49,10 +49,13 @@ public class MessageUpdateStat implements IMessage, IMessageHandler<MessageUpdat
         
         if (player != null)
         {
-            Capability<IPlayerStat> capability = (Capability<IPlayerStat>)PlayerStatRegistry.getCapability(message.identifier);
-            StatHandlerBase stat = (StatHandlerBase)player.getCapability(capability, null);
-            
-            capability.getStorage().readNBT(capability, stat, null, message.data);
+            Minecraft.getMinecraft().addScheduledTask(() ->
+            {
+                Capability<IPlayerStat> capability = (Capability<IPlayerStat>) PlayerStatRegistry.getCapability(message.identifier);
+                StatHandlerBase stat = (StatHandlerBase) player.getCapability(capability, null);
+
+                capability.getStorage().readNBT(capability, stat, null, message.data);
+            });
         }
         
         return null;


### PR DESCRIPTION
According to [ForgeDocs][ref-1], all data packets are handled on a networking thread, not the main game thread. As such, certain actions, such as accessing player or world data, are dangerous if they happen off-thread. This pull request is to address this issue.  
Sample stacktrace: https://paste.ubuntu.com/p/BfG6XmwRH3/. Do notice that Forge has no such detection mechanics, which means that there would be no such warning if I used Forge only; however that does not change the fact that accessing game objects off-thread is inappropriate.

[ref-1]: http://mcforge.readthedocs.io/en/latest/networking/simpleimpl/