### PR TITLE
Feature item nbt support candidate

### DIFF
--- a/src/main/java/toughasnails/config/json/ArmorTemperatureData.java
+++ b/src/main/java/toughasnails/config/json/ArmorTemperatureData.java
@@ -1,8 +1,14 @@
 package toughasnails.config.json;
 
 import com.google.gson.annotations.SerializedName;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import toughasnails.core.ToughAsNails;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class ArmorTemperatureData
@@ -11,10 +17,40 @@ public class ArmorTemperatureData
     public List<String> names;
     @SerializedName("modifier")
     public int modifier;
+    @SerializedName("nbts")
+    public List<String> nbts;
 
-    public ArmorTemperatureData(@Nonnull List<String> names, int modifier)
+    private List<NBTTagCompound> nbtTagCompounds;
+
+    public ArmorTemperatureData(@Nonnull List<String> names, int modifier, @Nonnull List<String> nbts)
     {
         this.names = names;
         this.modifier = modifier;
+        this.nbts = nbts;
+    }
+
+    public ArmorTemperatureData(@Nonnull List<String> names, int modifier) {
+        this(names, modifier, null);
+    }
+
+    public List<NBTTagCompound> getNBTTagCompounds() {
+        if (nbtTagCompounds == null) {
+            ArrayList<NBTTagCompound> compound = new ArrayList<>();
+
+            if (nbts == null) {
+                for (int i = 0; i < 4; i++) compound.add(null);
+            } else {
+                nbts.forEach(nbt -> {
+                    try {
+                        compound.add(JsonToNBT.getTagFromJson(nbt));
+                    } catch (NBTException e) {
+                        ToughAsNails.logger.error("Failed to parse NBT tag for ArmorTemperatureData: adding null NBT.  " +
+                                "This is likely an error. (First armor name: " + names.get(0) + ")");
+                    }
+                });
+            }
+            nbtTagCompounds = Collections.unmodifiableList(compound);
+        }
+        return nbtTagCompounds;
     }
 }

--- a/src/main/java/toughasnails/config/json/ItemPredicate.java
+++ b/src/main/java/toughasnails/config/json/ItemPredicate.java
@@ -16,6 +16,7 @@ import net.minecraft.nbt.NBTException;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import toughasnails.core.ToughAsNails;
+import toughasnails.util.config.NBTUtilExt;
 
 import javax.annotation.Nullable;
 
@@ -53,7 +54,7 @@ public class ItemPredicate implements Predicate<ItemStack>
         boolean areItemsEqual = input.isItemEqual(stack);
         NBTTagCompound ourTag = stack.getTagCompound();
         NBTTagCompound theirTag = input.getTagCompound();
-        boolean areTagsEqual = (nbt == null && theirTag == null) || (nbt != null && ourTag.equals(theirTag));
+        boolean areTagsEqual = NBTUtilExt.areNBTsEqualOrNull(ourTag, theirTag);
 
         return areItemsEqual && areTagsEqual;
     }

--- a/src/main/java/toughasnails/config/json/ItemPredicate.java
+++ b/src/main/java/toughasnails/config/json/ItemPredicate.java
@@ -11,7 +11,11 @@ import com.google.common.base.Predicate;
 import com.google.gson.annotations.SerializedName;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import toughasnails.core.ToughAsNails;
 
 import javax.annotation.Nullable;
 
@@ -20,11 +24,16 @@ public class ItemPredicate implements Predicate<ItemStack>
     @SerializedName("name")
     private String itemRegistryName;
     private int metadata;
+    private String nbt;
+
+    public ItemPredicate(ResourceLocation itemRegistryLoc, int metadata, String nbt) {
+        this.itemRegistryName = itemRegistryLoc.toString();
+        this.metadata = metadata;
+    }
 
     public ItemPredicate(ResourceLocation itemRegistryLoc, int metadata)
     {
-        this.itemRegistryName = itemRegistryLoc.toString();
-        this.metadata = metadata;
+        this(itemRegistryLoc, metadata, null);
     }
 
     public ItemPredicate(Item item, int metadata)
@@ -40,7 +49,13 @@ public class ItemPredicate implements Predicate<ItemStack>
     @Override
     public boolean apply(@Nullable ItemStack input)
     {
-        return input.isItemEqual(this.getItemStack());
+        ItemStack stack = this.getItemStack();
+        boolean areItemsEqual = input.isItemEqual(stack);
+        NBTTagCompound ourTag = stack.getTagCompound();
+        NBTTagCompound theirTag = input.getTagCompound();
+        boolean areTagsEqual = (nbt == null && theirTag == null) || (nbt != null && ourTag.equals(theirTag));
+
+        return areItemsEqual && areTagsEqual;
     }
 
     public ItemStack getItemStack()
@@ -49,7 +64,16 @@ public class ItemPredicate implements Predicate<ItemStack>
 
         if (item != null)
         {
-            return new ItemStack(item, 1, this.metadata);
+            ItemStack stack = new ItemStack(item, 1, this.metadata);
+            if (nbt != null) {
+                try {
+                    stack.setTagCompound(JsonToNBT.getTagFromJson(nbt));
+                } catch (NBTException e) {
+                    ToughAsNails.logger.error("Failed to parse NBT tag for ItemPredicate: ignoring NBT.  " +
+                            "This is likely an error. (Item Name: " + itemRegistryName + ")");
+                }
+            }
+            return stack;
         }
 
         return null;

--- a/src/main/java/toughasnails/temperature/modifier/ArmorModifier.java
+++ b/src/main/java/toughasnails/temperature/modifier/ArmorModifier.java
@@ -2,9 +2,13 @@ package toughasnails.temperature.modifier;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
 import toughasnails.api.temperature.IModifierMonitor;
 import toughasnails.api.temperature.Temperature;
 import toughasnails.init.ModConfig;
+import toughasnails.util.config.NBTUtilExt;
 
 import java.util.stream.IntStream;
 
@@ -22,7 +26,13 @@ public class ArmorModifier extends TemperatureModifier {
         int modifier = IntStream.range(0, 4)
                 .map(i -> ModConfig.armorTemperatureData.stream()
                         .filter(atd -> atd.names.contains(inventory.armorInventory.get(i)
-                        .getItem().getRegistryName().toString()))
+                                .getItem().getRegistryName().toString()))
+                        .filter(atd -> {
+                            int index = atd.names.indexOf(inventory.armorInventory.get(i).getItem().getRegistryName()
+                                    .toString());
+                            NBTTagCompound compare = atd.nbts == null ? null : atd.getNBTTagCompounds().get(index);
+                            return NBTUtilExt.areNBTsEqualOrNull(inventory.armorInventory.get(i).getTagCompound(), compare);
+                        })
                         .findFirst()
                         .map(atd -> atd.modifier).orElse(0)).sum();
         newTemperatureLevel += modifier;

--- a/src/main/java/toughasnails/util/config/NBTUtilExt.java
+++ b/src/main/java/toughasnails/util/config/NBTUtilExt.java
@@ -1,0 +1,10 @@
+package toughasnails.util.config;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public final class NBTUtilExt {
+
+    public static boolean areNBTsEqualOrNull(NBTTagCompound a, NBTTagCompound b) {
+        return (a == null && b == null) || (a != null && a.equals(b));
+    }
+}


### PR DESCRIPTION
This pull request resolves issue #517 

The ItemPredicate NBT comparisons have been tested to ensure that old features are not broken and the correct behaviour results from applying NBT data to the drinkable items.

The ArmorTemperature NBT comparisons have not been tested as I did not have a suitable test candidate or pre-existing testing setup in the code base to implement tests for.  For all intents and purposes, this one appears to function correctly.  This one can be easily removed from the commit tree if needed (as I think drinkables tend to have NBT data more often than Armor pieces).