### PR TITLE
Fix for null hand error if finish use event is called for non-held item

### DIFF
--- a/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
+++ b/src/main/java/toughasnails/handler/thirst/DrinkHandler.java
@@ -47,7 +47,7 @@ public class DrinkHandler
         if (event.getEntityLiving() instanceof EntityPlayer)
         {
             EntityPlayer player = (EntityPlayer)event.getEntityLiving();
-            ItemStack stack = player.getHeldItem(player.getActiveHand());
+            ItemStack stack = event.getItem();
             ThirstHandler thirstHandler = (ThirstHandler)ThirstHelper.getThirstData(player);
 
             if (thirstHandler.isThirsty())


### PR DESCRIPTION
Since this event is called from active hand itemstack update event already, it's better to reference that instead of checking active hand every time.