### PR TITLE
Make bonfire universal

### DIFF
--- a/src/main/java/toughasnails/block/BlockTANCampfire.java
+++ b/src/main/java/toughasnails/block/BlockTANCampfire.java
@@ -158,12 +158,12 @@ public class BlockTANCampfire extends Block implements ITANBlock
 			                return true;
 			            }
 			            
-			            if (item == Items.FLINT_AND_STEEL)
+			            if (item instanceof ItemFlintAndSteel)
 			            {
 			            	worldIn.playSound(playerIn, pos, SoundEvents.ITEM_FLINTANDSTEEL_USE, SoundCategory.BLOCKS, 1.0F, worldIn.rand.nextFloat() * 0.4F + 0.8F);
 			            	worldIn.setBlockState(pos, TANBlocks.campfire.getDefaultState().withProperty(BURNING, true));
 			
-			                if (item == Items.FLINT_AND_STEEL)
+			                if (item instanceof ItemFlintAndSteel)
 			                {
 			                    playerIn.getHeldItem(hand).damageItem(1, playerIn);
 			                }


### PR DESCRIPTION
I changed the rigid condition of only the vanilla flint and steel may activate the bonfire, to every item that extends the class Flint and Steel may activate it. Make it more compatible with other mods if they extended this class for their own lighters.