### PR TITLE
Fix HashMap ConcurrentModificationException

### DIFF
--- a/src/main/java/toughasnails/temperature/TemperatureHandler.java
+++ b/src/main/java/toughasnails/temperature/TemperatureHandler.java
@@ -77,14 +77,19 @@ public class TemperatureHandler extends StatHandlerBase implements ITemperature
 
             Iterator<Map.Entry<String, ExternalModifier>> it = externalModifiers.entrySet().iterator();
 
+            List<String> toRemove=new ArrayList<String>();
+
             while (it.hasNext())
             {
                 Map.Entry<String, ExternalModifier> entry = it.next();
 
                 if (entry.getValue().getEndTime() < this.temperatureTimer)
                 {
-                    this.externalModifiers.remove(entry.getKey());
+                    toRemove.add(entry.getKey());
                 }
+            }
+            for(String removeEntry: toRemove) {
+                this.externalModifiers.remove(removeEntry);
             }
 
             if (incrementTemperature)


### PR DESCRIPTION
```
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1445) ~[?:1.8.0_261]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1479) ~[?:1.8.0_261]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1477) ~[?:1.8.0_261]
        at toughasnails.temperature.TemperatureHandler.update(TemperatureHandler.java:82) ~[TemperatureHandler.class:?]
        at toughasnails.handler.ExtendedStatHandler.onPlayerTick(ExtendedStatHandler.java:69) ~[ExtendedStatHandler.class:?]
        at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_1825_ExtendedStatHandler_onPlayerTick_PlayerTickEvent.invoke(.dynamic) ~[?:?]
        at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90) ~[ASMEventHandler.class:?]
        at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:182) ~[EventBus.class:?]
        at net.minecraftforge.fml.common.FMLCommonHandler.onPlayerPostTick(FMLCommonHandler.java:370) ~[FMLCommonHandler.class:?]
        at net.minecraft.entity.player.EntityPlayer.func_184808_cD(EntityPlayer.java:378) ~[aed.class:?]
        at net.minecraft.entity.player.EntityPlayer.func_70071_h_(EntityPlayer.java:288) ~[aed.class:?]
        at net.minecraft.entity.player.EntityPlayerMP.func_71127_g(EntityPlayerMP.java:382) ~[oq.class:?]
        ... 9 more

```