### PR TITLE
change accessibility of drawTemperature and drawThirst

### DIFF
--- a/common/src/main/java/toughasnails/temperature/TemperatureOverlayRenderer.java
+++ b/common/src/main/java/toughasnails/temperature/TemperatureOverlayRenderer.java
@@ -70,7 +70,7 @@ public class TemperatureOverlayRenderer
         }
     }
 
-    private static void renderTemperature(GuiGraphics guiGraphics, float partialTicks, int width, int height)
+    public static void renderTemperature(GuiGraphics guiGraphics, float partialTicks, int width, int height)
     {
         Minecraft minecraft = Minecraft.getInstance();
 

--- a/common/src/main/java/toughasnails/thirst/ThirstOverlayRenderer.java
+++ b/common/src/main/java/toughasnails/thirst/ThirstOverlayRenderer.java
@@ -59,7 +59,7 @@ public class ThirstOverlayRenderer
         }
     }
 
-    private static void drawThirst(GuiGraphics guiGraphics, int screenWidth, int rowTop, int thirstLevel, float thirstHydrationLevel)
+    public static void drawThirst(GuiGraphics guiGraphics, int screenWidth, int rowTop, int thirstLevel, float thirstHydrationLevel)
     {
         Minecraft minecraft = Minecraft.getInstance();
         Player player = minecraft.player;


### PR DESCRIPTION
Hello, I'm a developer of an HUD mod, since I will disable some vanilla overlays in my mod, the temperature and thirst overlay will also be hidden( because TAN uses mixin to render overlays ), by making this two methods public, I can call them in my mod, so the overlays won't be hidden when vanilla food or air rendering is canceled.