### PR TITLE
Fix Armors full stack

### DIFF
--- a/common/src/main/java/toughasnails/init/ModItems.java
+++ b/common/src/main/java/toughasnails/init/ModItems.java
@@ -30,15 +30,15 @@ public class ModItems
         // Items
         TANItems.THERMOMETER = register(func, "thermometer", new Item(new Item.Properties().stacksTo(1)));
 
-        TANItems.LEAF_HELMET = register(func, "leaf_helmet", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.HELMET, (new Item.Properties())));
-        TANItems.LEAF_CHESTPLATE = register(func, "leaf_chestplate", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.CHESTPLATE, (new Item.Properties())));
-        TANItems.LEAF_LEGGINGS = register(func, "leaf_leggings", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.LEGGINGS, (new Item.Properties())));
-        TANItems.LEAF_BOOTS = register(func, "leaf_boots", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.BOOTS, (new Item.Properties())));
+        TANItems.LEAF_HELMET = register(func, "leaf_helmet", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.HELMET, (new Item.Properties().stacksTo(1))));
+        TANItems.LEAF_CHESTPLATE = register(func, "leaf_chestplate", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.CHESTPLATE, (new Item.Properties().stacksTo(1))));
+        TANItems.LEAF_LEGGINGS = register(func, "leaf_leggings", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.LEGGINGS, (new Item.Properties().stacksTo(1))));
+        TANItems.LEAF_BOOTS = register(func, "leaf_boots", new LeafArmorItem(ModArmorMaterials.LEAF, ArmorItem.Type.BOOTS, (new Item.Properties().stacksTo(1))));
 
-        TANItems.WOOL_HELMET = register(func, "wool_helmet", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.HELMET, (new Item.Properties())));
-        TANItems.WOOL_CHESTPLATE = register(func, "wool_chestplate", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.CHESTPLATE, (new Item.Properties())));
-        TANItems.WOOL_LEGGINGS = register(func, "wool_leggings", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.LEGGINGS, (new Item.Properties())));
-        TANItems.WOOL_BOOTS = register(func, "wool_boots", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.BOOTS, (new Item.Properties())));
+        TANItems.WOOL_HELMET = register(func, "wool_helmet", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.HELMET, (new Item.Properties().stacksTo(1))));
+        TANItems.WOOL_CHESTPLATE = register(func, "wool_chestplate", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.CHESTPLATE, (new Item.Properties().stacksTo(1))));
+        TANItems.WOOL_LEGGINGS = register(func, "wool_leggings", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.LEGGINGS, (new Item.Properties().stacksTo(1))));
+        TANItems.WOOL_BOOTS = register(func, "wool_boots", new WoolArmorItem(ModArmorMaterials.WOOL, ArmorItem.Type.BOOTS, (new Item.Properties().stacksTo(1))));
 
         TANItems.ICE_CREAM = register(func, "ice_cream", new StackableBowlFoodItem(new Item.Properties().stacksTo(16).food(new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).alwaysEdible().build())));
         TANItems.CHARC_0S = register(func, "charc_os", new StackableBowlFoodItem(new Item.Properties().stacksTo(16).food(new FoodProperties.Builder().nutrition(0).saturationModifier(0.0F).alwaysEdible().build())));


### PR DESCRIPTION
In the latest version, wool and leaves armor can be stacked in 64, I don't know if this is intentional but I suggest this change if it's not normal. Normally, when you drag armors (Shift+Click), only one is equipped, but in a recent version, you just have to right-click to equip it automatically. 
![2024-08-17_19 16 40](https://github.com/user-attachments/assets/7e68c83b-33cc-421d-a3c0-118acfedfd0a)
With a stack of TAN armors, they're all equipped at once.
![2024-08-17_19 17 28](https://github.com/user-attachments/assets/985875ab-1eb1-41ce-8686-dd6ae390b380)