### PR TITLE
[BUGFIX] Deleted Code that caused incompatibility with NutritionZ

### DIFF
--- a/common/src/main/java/toughasnails/mixin/MixinFoodData.java
+++ b/common/src/main/java/toughasnails/mixin/MixinFoodData.java
@@ -19,6 +19,5 @@ public abstract class MixinFoodData
     public void onTick(Player player, CallbackInfo ci)
     {
         ThirstHooks.doFoodDataTick((FoodData)(Object)this, player);
-        ci.cancel();
     }
 }

--- a/common/src/main/java/toughasnails/thirst/ThirstHooks.java
+++ b/common/src/main/java/toughasnails/thirst/ThirstHooks.java
@@ -30,20 +30,6 @@ public class ThirstHooks
 
         data.lastFoodLevel = data.foodLevel;
 
-        if (data.exhaustionLevel > 4.0F)
-        {
-            data.exhaustionLevel -= 4.0F;
-
-            if (data.saturationLevel > 0.0F)
-            {
-                data.saturationLevel = Math.max(data.saturationLevel - 1.0F, 0.0F);
-            }
-            else if (difficulty != Difficulty.PEACEFUL)
-            {
-                data.foodLevel = Math.max(data.foodLevel - 1, 0);
-            }
-        }
-
         boolean naturalRegen = player.level().getGameRules().getBoolean(GameRules.RULE_NATURAL_REGENERATION);
 
         if (naturalRegen && data.saturationLevel > 0.0F && player.isHurt() && data.foodLevel >= 20 && (!ModConfig.thirst.thirstPreventHealthRegen || (thirst.getHydration() > 0.0F && thirst.getThirst() >= 20)))


### PR DESCRIPTION
While playing with both NutritionZ (1.0.11+1.21.1) and TAN (9.2.0.171+1.21.1) on Fabric, I discoverd a major incompatibility between these two mods causing NutritionZ to not track lost nutritional values.Normally in NutritionZ if you would lose hunger your nutritional values would go down by one unit, however when installing both this behavior would not work at all. 

While looking at the source code of both mods I discoverd that NutritionZ uses mixins to alter the behavior of HungerManager.class where foodTickTimer resides. I am no expert in modding but by trial and error I found that these lines in TAN would cause a problem for NutritionZ.

[Mixin in NutritionZ](https://github.com/xR4YM0ND/NutritionZ/blob/6d1fe779823c66b41c59cf9508ec90984e4f8c8d/src/main/java/net/nutritionz/mixin/HungerManagerMixin.java#L51)

I did this for my own survival world and I thought maybe other people might run into the same problem without knowledge in java.

Love your contribution to the community, much love!

EDIT:
My Discord: Marvin23